### PR TITLE
feat: add `uri` param to `marshall` and deprecate `type_base_url`

### DIFF
--- a/src/rfc9457/__init__.py
+++ b/src/rfc9457/__init__.py
@@ -79,12 +79,15 @@ class Problem(Exception):  # noqa: N818
         if type_base_url
             typ = f"{type_base_url or ''}{self.type}"
             warn("Using deprecated parameter 'type_base_url'", DeprecationWarning)
-        typ = uri.replace("{status}", self.status).replace("{title}", self.title).replace("{type}", self.type) or self.type
+        # example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{status}"
+        typ = uri.format(status=self.status, type=self.type_, title=self.title, **self.extras) or typ
         return {
             "type": typ,
             "title": self.title,
             "status": self.status,
+            # if strip_debug, restrict extras to __mandatory__
             **{k: v for k, v in self.extras.items() if k in self.__mandatory__ or not strip_debug},
+            # similarly (if strip_debug), exclude detail if "detail" is not in __mandatory__
             **{"detail": d for d in [detail] if d and ("detail" in self.__mandatory__ or not strip_debug)},
         }
 

--- a/src/rfc9457/__init__.py
+++ b/src/rfc9457/__init__.py
@@ -81,9 +81,9 @@ class Problem(Exception):  # noqa: N818
         """
         type_ = self.type
         if type_base_url:
-            type_ = f"{type_base_url or ''}{self.type}"
+            type_ = f"{type_base_url}{self.type}"
             warn(
-                "Using deprecated parameter 'type_base_url'",
+                "Using deprecated parameter 'type_base_url', switch to 'uri'",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/tests/test_rfc9457.py
+++ b/tests/test_rfc9457.py
@@ -53,6 +53,17 @@ def test_marshal_with_base_url():
     }
 
 
+def test_marshal_with_uri():
+    e = NotFoundError("detail")
+
+    assert e.marshal(uri="https://my-docs/errors/{status}/{type}") == {
+        "type": "https://my-docs/errors/404/not-found",
+        "title": "a 404 message",
+        "detail": "detail",
+        "status": 404,
+    }
+
+
 @pytest.mark.parametrize(
     "exc",
     [
@@ -81,6 +92,18 @@ def test_repr(exc):
     e = exc("detail")
 
     assert repr(e) == f"{exc.__name__}<title={e.title}; detail=detail>"
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        " ",
+        "type",
+    ],
+)
+def test_init_with_bad_extras(extra):
+    with pytest.raises(ValueError, match=f"Illegal extra keys: {{'{extra}'}}"):
+        NotFoundError(**{extra: "value"})
 
 
 def test_marshal_with_extras():


### PR DESCRIPTION
# feat: add `uri` param to `marshall` and deprecate `type_base_url`

Replace `type_base_url` with `uri`, which is either the `type` URI or a template URI
(see RFC 6570) with keys `status`, `title`, and `type`. This enables working with URIs that do not use (or do not only use) this package's auto-generated values. For example, pass `uri="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{status}"`.

Fixes #6 